### PR TITLE
add MIT license to gempsec

### DIFF
--- a/jpbuilder.gemspec
+++ b/jpbuilder.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split("\n")
   gem.name          = "jpbuilder"
   gem.require_paths = ["lib"]
+  gem.license       = "MIT"
 
   gem.add_dependency "jbuilder"
 end


### PR DESCRIPTION
Just trying to make the world a better place at a local ruby users group meeting tonight! Updated the gemspec to reflect the license that is in the LICENSE file.

http://www.benjaminfleischer.com/2013/07/12/make-the-world-a-better-place-put-a-license-in-your-gemspec/
