### PR TITLE
Use recommended Mime[:json] instead of Mime::Json

### DIFF
--- a/lib/jpbuilder-handler.rb
+++ b/lib/jpbuilder-handler.rb
@@ -2,7 +2,7 @@ require "jbuilder"
 
 class JPbuilderHandler
   cattr_accessor :default_format, :default_callback
-  self.default_format = Mime::JSON
+  self.default_format = Mime[:json]
   self.default_callback = nil
 
   def self.call(template)


### PR DESCRIPTION
# Summary
This pull-req uses the recommended method instead of `Mime::Json`.

## Deprecation log
```
DEPRECATION WARNING: Accessing mime types via constants is deprecated. Please change `Mime::JSON` to `Mime[:json]`.
```